### PR TITLE
Removed test for end date, and change start and end date for annual summary

### DIFF
--- a/pydaymet/core.py
+++ b/pydaymet/core.py
@@ -278,6 +278,9 @@ class Daymet:
         if self.time_scale == "monthly":
             start = start.replace(day=14)
             end = end.replace(day=17)
+        if self.time_scale == "annual":
+            start = start.replace(month=6)
+            end = end.replace(month=8)
 
         if start < self.valid_start:
             raise InvalidInputRange(self._invalid_yr)

--- a/pydaymet/core.py
+++ b/pydaymet/core.py
@@ -215,9 +215,8 @@ class Daymet:
             self.valid_start = pd.to_datetime("1950-01-01")
         else:
             self.valid_start = pd.to_datetime("1980-01-01")
-        self.valid_end = pd.to_datetime("2020-12-31")
         self._invalid_yr = (
-            "Daymet database ranges from " + f"{self.valid_start.year} to {self.valid_end.year}."
+            "Daymet database dates must be greater than " + f"{self.valid_start.year}."
         )
         self.time_codes = {"daily": 1840, "monthly": 1855, "annual": 1852}
 
@@ -280,7 +279,7 @@ class Daymet:
             start = start.replace(day=14)
             end = end.replace(day=17)
 
-        if start < self.valid_start or end > self.valid_end:
+        if start < self.valid_start:
             raise InvalidInputRange(self._invalid_yr)
 
         return {
@@ -292,7 +291,7 @@ class Daymet:
         """Set date by list of year(s)."""
         years = [years] if isinstance(years, int) else years
 
-        if min(years) < self.valid_start.year or max(years) > self.valid_end.year:
+        if min(years) < self.valid_start.year:
             raise InvalidInputRange(self._invalid_yr)
 
         return {"years": ",".join(str(y) for y in years)}


### PR DESCRIPTION
The end date that input end dates was tested against was 2020-12-31 and it should have been 2021-12-31.  Removed the test because the web services doesn't error out if you put a later end date.  It will just return everything that it has.

Also change the start and end dates for the "annual" time_scale since had to encompass dates early in July.

Kind regards,
Tim